### PR TITLE
Add SQLite-backed sync log for upload, merge and delete actions

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
 GOOGLE_MAPS_API_KEY=

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
 GOOGLE_MAPS_API_KEY=

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'src/services/firebase_uid_service.dart';
 import 'src/services/google_pay_expense_import_service.dart';
 import 'src/services/local_notification_service.dart';
 import 'src/services/local_storage_service.dart';
+import 'src/services/sync_log_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -68,6 +69,13 @@ class _BootstrapAppState extends State<_BootstrapApp> {
       await BackgroundTaskService.initialize();
     } catch (error) {
       debugPrint('Error initializing background tasks: $error');
+    }
+
+    try {
+      await SyncLogService.init();
+      debugPrint('SyncLogService initialized');
+    } catch (error) {
+      debugPrint('Error initializing SyncLogService: $error');
     }
 
     try {

--- a/lib/src/services/cloud_sync_service.dart
+++ b/lib/src/services/cloud_sync_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
@@ -12,6 +14,7 @@ import 'app_time_format_service.dart';
 import 'auth_memory_store.dart';
 import 'firebase_uid_service.dart';
 import 'local_storage_service.dart';
+import 'sync_log_service.dart';
 
 class CloudSyncSummary {
   const CloudSyncSummary({
@@ -139,6 +142,7 @@ class CloudSyncService {
 
   Future<bool> deleteExpenseRecord(ExpenseModel expense) async {
     return _deleteRecord(
+      entityType: SyncLogService.entityExpense,
       collectionName: 'expenses',
       serverId: expense.serverId,
       fallbackDocumentId: _canonicalExpenseDocumentId(expense),
@@ -148,6 +152,7 @@ class CloudSyncService {
 
   Future<bool> deleteIncomeRecord(IncomeModel income) async {
     return _deleteRecord(
+      entityType: SyncLogService.entityIncome,
       collectionName: 'incomes',
       serverId: income.serverId,
       fallbackDocumentId: _canonicalIncomeDocumentId(income),
@@ -157,6 +162,7 @@ class CloudSyncService {
 
   Future<bool> deleteGoalRecord(GoalModel goal) async {
     return _deleteRecord(
+      entityType: SyncLogService.entityGoal,
       collectionName: 'goals',
       serverId: goal.serverId,
       fallbackDocumentId: _canonicalGoalDocumentId(goal),
@@ -226,8 +232,20 @@ class CloudSyncService {
         );
         await _localStorage.markExpenseAsSynced(index, documentId);
         uploadedExpenses++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityExpense,
+          entityId: documentId,
+          action: SyncLogService.actionUpload,
+          success: true,
+        ));
       } catch (_) {
         failures++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityExpense,
+          entityId: expense.serverId,
+          action: SyncLogService.actionUpload,
+          success: false,
+        ));
       }
     }
 
@@ -263,8 +281,20 @@ class CloudSyncService {
         );
         await _localStorage.markIncomeAsSynced(index, documentId);
         uploadedIncomes++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityIncome,
+          entityId: documentId,
+          action: SyncLogService.actionUpload,
+          success: true,
+        ));
       } catch (_) {
         failures++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityIncome,
+          entityId: income.serverId,
+          action: SyncLogService.actionUpload,
+          success: false,
+        ));
       }
     }
 
@@ -300,8 +330,20 @@ class CloudSyncService {
         );
         await _localStorage.markGoalAsSynced(index, documentId);
         uploadedGoals++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityGoal,
+          entityId: documentId,
+          action: SyncLogService.actionUpload,
+          success: true,
+        ));
       } catch (_) {
         failures++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityGoal,
+          entityId: goal.serverId,
+          action: SyncLogService.actionUpload,
+          success: false,
+        ));
       }
     }
 
@@ -324,8 +366,20 @@ class CloudSyncService {
         );
         await _localStorage.markLabelAsSynced(index, documentId);
         uploadedLabels++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityLabel,
+          entityId: documentId,
+          action: SyncLogService.actionUpload,
+          success: true,
+        ));
       } catch (_) {
         failures++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityLabel,
+          entityId: label.serverId,
+          action: SyncLogService.actionUpload,
+          success: false,
+        ));
       }
     }
 
@@ -357,8 +411,20 @@ class CloudSyncService {
         );
         await _localStorage.markUserAsSynced(index, documentId);
         uploadedUsers++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityUser,
+          entityId: documentId,
+          action: SyncLogService.actionUpload,
+          success: true,
+        ));
       } catch (_) {
         failures++;
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityUser,
+          entityId: user.serverId,
+          action: SyncLogService.actionUpload,
+          success: false,
+        ));
       }
     }
 
@@ -430,28 +496,45 @@ class CloudSyncService {
       return;
     }
 
-    final username = _stringValue(
-      data['username'],
-      fallback: _normalizedUsername(localUser),
-    );
-    localUser
-      ..firebaseUid = _stringValue(data['uid'], fallback: snapshot.id)
-      ..username = username
-      ..email = _stringValue(data['email'], fallback: localUser.email)
-      ..displayName =
-          _stringOrNull(data['displayName'], fallback: localUser.displayName) ??
-          username
-      ..handle =
-          _stringOrNull(data['handle'], fallback: localUser.handle) ??
-          _normalizedHandle(localUser, username)
-      ..createdAt = _dateTimeValue(data['createdAt']) ?? localUser.createdAt
-      ..isSynced = true
-      ..serverId = snapshot.id;
-    await localUser.save();
+    try {
+      final username = _stringValue(
+        data['username'],
+        fallback: _normalizedUsername(localUser),
+      );
+      localUser
+        ..firebaseUid = _stringValue(data['uid'], fallback: snapshot.id)
+        ..username = username
+        ..email = _stringValue(data['email'], fallback: localUser.email)
+        ..displayName =
+            _stringOrNull(data['displayName'], fallback: localUser.displayName) ??
+            username
+        ..handle =
+            _stringOrNull(data['handle'], fallback: localUser.handle) ??
+            _normalizedHandle(localUser, username)
+        ..createdAt = _dateTimeValue(data['createdAt']) ?? localUser.createdAt
+        ..isSynced = true
+        ..serverId = snapshot.id;
+      await localUser.save();
 
-    final currentUsername = AuthMemoryStore.currentState.username?.trim() ?? '';
-    if (currentUsername != username) {
-      await AuthMemoryStore.updateCurrentUsername(username);
+      final currentUsername = AuthMemoryStore.currentState.username?.trim() ?? '';
+      if (currentUsername != username) {
+        await AuthMemoryStore.updateCurrentUsername(username);
+      }
+
+      unawaited(SyncLogService.logSync(
+        entityType: SyncLogService.entityUser,
+        entityId: snapshot.id,
+        action: SyncLogService.actionMerge,
+        success: true,
+      ));
+    } catch (error) {
+      debugPrint('Cloud sync merge user failed: $error');
+      unawaited(SyncLogService.logSync(
+        entityType: SyncLogService.entityUser,
+        entityId: snapshot.id,
+        action: SyncLogService.actionMerge,
+        success: false,
+      ));
     }
   }
 
@@ -460,6 +543,7 @@ class CloudSyncService {
     required int localUserId,
   }) async {
     for (final document in snapshot.docs) {
+      try {
       final existingExpense = _findByServerId(
         LocalStorageService.expenseBox.values,
         document.id,
@@ -551,6 +635,22 @@ class CloudSyncService {
       } else {
         await expense.save();
       }
+
+      unawaited(SyncLogService.logSync(
+        entityType: SyncLogService.entityExpense,
+        entityId: document.id,
+        action: SyncLogService.actionMerge,
+        success: true,
+      ));
+      } catch (error) {
+        debugPrint('Cloud sync merge expense ${document.id} failed: $error');
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityExpense,
+          entityId: document.id,
+          action: SyncLogService.actionMerge,
+          success: false,
+        ));
+      }
     }
   }
 
@@ -559,6 +659,7 @@ class CloudSyncService {
     required int localUserId,
   }) async {
     for (final document in snapshot.docs) {
+      try {
       final existingIncome = _findByServerId(
         LocalStorageService.incomeBox.values,
         document.id,
@@ -599,6 +700,22 @@ class CloudSyncService {
       } else {
         await income.save();
       }
+
+      unawaited(SyncLogService.logSync(
+        entityType: SyncLogService.entityIncome,
+        entityId: document.id,
+        action: SyncLogService.actionMerge,
+        success: true,
+      ));
+      } catch (error) {
+        debugPrint('Cloud sync merge income ${document.id} failed: $error');
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityIncome,
+          entityId: document.id,
+          action: SyncLogService.actionMerge,
+          success: false,
+        ));
+      }
     }
   }
 
@@ -607,6 +724,7 @@ class CloudSyncService {
     required int localUserId,
   }) async {
     for (final document in snapshot.docs) {
+      try {
       final existingGoal = _findByServerId(
         LocalStorageService.goalBox.values,
         document.id,
@@ -643,6 +761,22 @@ class CloudSyncService {
       } else {
         await goal.save();
       }
+
+      unawaited(SyncLogService.logSync(
+        entityType: SyncLogService.entityGoal,
+        entityId: document.id,
+        action: SyncLogService.actionMerge,
+        success: true,
+      ));
+      } catch (error) {
+        debugPrint('Cloud sync merge goal ${document.id} failed: $error');
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityGoal,
+          entityId: document.id,
+          action: SyncLogService.actionMerge,
+          success: false,
+        ));
+      }
     }
   }
 
@@ -651,6 +785,7 @@ class CloudSyncService {
     required int localUserId,
   }) async {
     for (final document in snapshot.docs) {
+      try {
       final existingLabel = _findByServerId(
         LocalStorageService.labelBox.values,
         document.id,
@@ -678,6 +813,22 @@ class CloudSyncService {
         await _localStorage.saveLabel(label);
       } else {
         await label.save();
+      }
+
+      unawaited(SyncLogService.logSync(
+        entityType: SyncLogService.entityLabel,
+        entityId: document.id,
+        action: SyncLogService.actionMerge,
+        success: true,
+      ));
+      } catch (error) {
+        debugPrint('Cloud sync merge label ${document.id} failed: $error');
+        unawaited(SyncLogService.logSync(
+          entityType: SyncLogService.entityLabel,
+          entityId: document.id,
+          action: SyncLogService.actionMerge,
+          success: false,
+        ));
       }
     }
   }
@@ -941,6 +1092,7 @@ class CloudSyncService {
   }
 
   Future<bool> _deleteRecord({
+    required String entityType,
     required String collectionName,
     required String? serverId,
     required String fallbackDocumentId,
@@ -956,7 +1108,25 @@ class CloudSyncService {
       );
     }
 
-    await deleteLocal();
+    try {
+      await deleteLocal();
+    } catch (error) {
+      unawaited(SyncLogService.logSync(
+        entityType: entityType,
+        entityId: serverId ?? fallbackDocumentId,
+        action: SyncLogService.actionDelete,
+        success: false,
+      ));
+      rethrow;
+    }
+
+    unawaited(SyncLogService.logSync(
+      entityType: entityType,
+      entityId: serverId ?? fallbackDocumentId,
+      action: SyncLogService.actionDelete,
+      success: deletedFromCloud,
+    ));
+
     return deletedFromCloud;
   }
 

--- a/lib/src/services/sync_log_service.dart
+++ b/lib/src/services/sync_log_service.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+
+abstract final class SyncLogService {
+  static const actionUpload = 'upload';
+  static const actionMerge = 'merge';
+  static const actionDelete = 'delete';
+
+  static const entityExpense = 'expense';
+  static const entityIncome = 'income';
+  static const entityGoal = 'goal';
+  static const entityLabel = 'label';
+  static const entityUser = 'user';
+
+  static const _dbFileName = 'sync_logs.db';
+  static const _tableName = 'sync_logs';
+  static const _dbVersion = 1;
+
+  static Database? _db;
+
+  static Future<void> init() async {
+    if (kIsWeb) {
+      return;
+    }
+    if (_db != null) {
+      return;
+    }
+
+    try {
+      final dbPath = await getDatabasesPath();
+      final path = p.join(dbPath, _dbFileName);
+      _db = await openDatabase(
+        path,
+        version: _dbVersion,
+        onCreate: (db, version) async {
+          await db.execute('''
+            CREATE TABLE $_tableName (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              entity_type TEXT NOT NULL,
+              entity_id TEXT,
+              action TEXT NOT NULL,
+              timestamp INTEGER NOT NULL,
+              success INTEGER NOT NULL
+            )
+          ''');
+          await db.execute(
+            'CREATE INDEX idx_sync_logs_success ON $_tableName(success)',
+          );
+          await db.execute(
+            'CREATE INDEX idx_sync_logs_timestamp ON $_tableName(timestamp DESC)',
+          );
+        },
+      );
+    } catch (error) {
+      debugPrint('SyncLogService.init failed: $error');
+      _db = null;
+    }
+  }
+
+  static Future<void> logSync({
+    required String entityType,
+    String? entityId,
+    required String action,
+    required bool success,
+  }) async {
+    if (kIsWeb) {
+      return;
+    }
+    final db = _db;
+    if (db == null) {
+      return;
+    }
+
+    try {
+      await db.insert(_tableName, {
+        'entity_type': entityType,
+        'entity_id': entityId,
+        'action': action,
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+        'success': success ? 1 : 0,
+      });
+    } catch (error) {
+      debugPrint('SyncLogService.logSync failed: $error');
+    }
+  }
+
+  static Future<List<Map<String, Object?>>> recentLogs({int limit = 100}) async {
+    if (kIsWeb) {
+      return const [];
+    }
+    final db = _db;
+    if (db == null) {
+      return const [];
+    }
+
+    try {
+      return await db.query(
+        _tableName,
+        orderBy: 'timestamp DESC',
+        limit: limit,
+      );
+    } catch (error) {
+      debugPrint('SyncLogService.recentLogs failed: $error');
+      return const [];
+    }
+  }
+
+  static Future<List<Map<String, Object?>>> failedLogs({int limit = 100}) async {
+    if (kIsWeb) {
+      return const [];
+    }
+    final db = _db;
+    if (db == null) {
+      return const [];
+    }
+
+    try {
+      return await db.query(
+        _tableName,
+        where: 'success = ?',
+        whereArgs: [0],
+        orderBy: 'timestamp DESC',
+        limit: limit,
+      );
+    } catch (error) {
+      debugPrint('SyncLogService.failedLogs failed: $error');
+      return const [];
+    }
+  }
+}

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -17,6 +17,7 @@ import geolocator_apple
 import local_auth_darwin
 import package_info_plus
 import shared_preferences_foundation
+import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -31,4 +32,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1293,6 +1293,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "5e8377564d95166761a968ed96104e0569b6b6cc611faac92a36ab8a169112c3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6+1"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1341,6 +1381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "33.1.44"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   timezone: ^0.10.1
   firebase_analytics: ^12.2.0
   workmanager: ^0.7.0
+  sqflite: ^2.4.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- New dependency: `sqflite: ^2.4.2`                                                                              
  - New service `lib/src/services/sync_log_service.dart` — `init()`, `logSync(...)`, `recentLogs()`,
  `failedLogs()`. No-op on web.                                                                                    
  - `main.dart` — initializes the service in the optional-services block (non-blocking).
  - `cloud_sync_service.dart` — fire-and-forget `logSync(...)` after every upload, merge and delete (success and   
  failure paths), for all 5 entities. Per-document try/catch added to merge methods so one bad doc no longer aborts
   the whole merge.